### PR TITLE
Make 3.9 to be minimal supported version as manuscript says

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [{name = "Martin Bernstorff", email = "martinbernstorff@gmail.com"},
     {name = "Jakob Grøhn Damgaard", email = "bokajgd@gmail.com"},
     {name = "Kenneth Enevoldsen"}]
 
-requires-python = ">=3.8.0"
+requires-python = ">=3.9.0"
 
 dependencies = [
     "scipy>=1.8.0,<1.9.4",


### PR DESCRIPTION
may be that is not what you want really since 3.8 is still widely used and supported by Python, but your JOSS manuscript says 3.9+. But only 3.9 is tested ATM

related, re + in 3.9: https://github.com/Aarhus-Psychiatry-Research/timeseriesflattener/issues/133