### PR TITLE
ci: add python 3.8, 3.10 compatability

### DIFF
--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -4,14 +4,23 @@ inputs:
   python-version:
     description: "Which Python version to run on"
     required: true
-    default: 3.9
+    default: "3.9"
 
 runs:
   using: "composite"
   steps:
     ### Setup prerequisites
+    - name: Cache venv
+      uses: actions/cache@v3.2.6
+      id: cache_venv
+      with:
+        path: |
+          .venv
+        key: ${{ runner.os }}-venv-${{ matrix.python-version }}-${{ hashFiles('**/pyproject.toml') }}
+
     - name: Set up Python
       uses: actions/setup-python@v4
+      if: steps.cache_venv.outputs.cache-hit != 'true'
       with:
         python-version: ${{ inputs.python-version }}
         cache: "pip"

--- a/.github/workflows/main_test_and_release.yml
+++ b/.github/workflows/main_test_and_release.yml
@@ -17,12 +17,13 @@ env:
 jobs:
   test:
     runs-on: ${{ matrix.os }}
-    env:
-      python-version: 3.9
-
     strategy:
       matrix:
         os: [ubuntu-latest]
+        python-version: [3.9, 3.10, 3.11]
+
+    env:
+      python-version: ${{ matrix.python-version }}
 
     # This allows a subsequently queued workflow run to interrupt previous runs
     concurrency:
@@ -41,7 +42,7 @@ jobs:
   jupyter-tutorials:
     runs-on: ${{ matrix.os }}
     env:
-      python-version: 3.9
+      python-version: ${{ matrix.os }}
 
     strategy:
       matrix:

--- a/.github/workflows/main_test_and_release.yml
+++ b/.github/workflows/main_test_and_release.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10"]
 
     env:
       python-version: ${{ matrix.python-version }}

--- a/.github/workflows/main_test_and_release.yml
+++ b/.github/workflows/main_test_and_release.yml
@@ -20,14 +20,14 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.9, 3.10, 3.11]
+        python-version: ["3.9", "3.10", "3.11"]
 
     env:
       python-version: ${{ matrix.python-version }}
 
     # This allows a subsequently queued workflow run to interrupt previous runs
     concurrency:
-      group: "${{ github.workflow }} - ${{ matrix.os }} @ ${{ github.ref }}"
+      group: "${{ github.workflow }} - ${{ matrix.python-version}} ${{ matrix.os }} @ ${{ github.ref }}"
       cancel-in-progress: true
 
     steps:

--- a/.github/workflows/main_test_and_release.yml
+++ b/.github/workflows/main_test_and_release.yml
@@ -42,7 +42,7 @@ jobs:
   jupyter-tutorials:
     runs-on: ${{ matrix.os }}
     env:
-      python-version: ${{ matrix.os }}
+      python-version: ${{ matrix.python-version }}
 
     strategy:
       matrix:

--- a/.github/workflows/main_test_and_release.yml
+++ b/.github/workflows/main_test_and_release.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.9", "3.10"]
 
     env:
       python-version: ${{ matrix.python-version }}

--- a/.github/workflows/main_test_and_release.yml
+++ b/.github/workflows/main_test_and_release.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10"]
 
     env:
       python-version: ${{ matrix.python-version }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,12 +27,12 @@ dependencies = [
     "catalogue>=2.0.0, <2.1.0",
     "numpy>=1.23.3,<1.24.2",
     "pyarrow>=9.0.0,<11.1.0",
-    "psycopmlutils>=0.2.4,<0.4.0",
     "protobuf<=3.20.3", # Other versions give errors with pytest, super weird!
     "frozendict>=2.3.4,<2.4.0",
     "skimpy>=0.0.7,<0.1.0",
     "jupyter>=1.0.0,<1.1.0",
     "coloredlogs>14.0.0,<15.1.0",
+    "psycopmlutils>=0.5.0, <0.12.0",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [{name = "Martin Bernstorff", email = "martinbernstorff@gmail.com"},
     {name = "Jakob Grøhn Damgaard", email = "bokajgd@gmail.com"},
     {name = "Kenneth Enevoldsen"}]
 
-requires-python = ">=3.8.0"
+requires-python = ">=3.8.0,<3.11.0"
 
 dependencies = [
     "scipy>=1.8.0,<1.9.4",
@@ -61,8 +61,7 @@ docs = [
 text = [
     "transformers>=4.26.0,<4.27.0",
     "torch>=1.0.0,<1.14.0",
-    "sentence-transformers>=2.0.0,<2.5.0",
-    "scikit-learn>=1.1.2,<1.4.0",
+    "sentence-transformers>=1.0.0,<2.5.0",
 ]
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [{name = "Martin Bernstorff", email = "martinbernstorff@gmail.com"},
     {name = "Jakob Grøhn Damgaard", email = "bokajgd@gmail.com"},
     {name = "Kenneth Enevoldsen"}]
 
-requires-python = ">=3.9.0,<3.11.0"
+requires-python = ">=3.8.0,<3.11.0"
 
 dependencies = [
     "scipy>=1.8.0,<1.9.4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,13 +37,13 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-    "pytest>=7.1.3, <7.2.3",
     "black>=22.8.0,<23.1.1",
     "pre-commit>=2.20.0,<3.1.1",
-    "pytest-cov>=3.0.0,<4.0.1",
     "flake8>=5.0.0, <5.0.6",
     "docformatter>=1.5.0, <1.5.2",
     "mypy>=0.971,<0.992",
+    "pytest>=7.1.3, <7.2.3",
+    "pytest-cov>=3.0.0,<4.0.1",
     "pytest-xdist>=2.4.0,<3.1.1",
     "pylint>=2.15.5,<2.17.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [{name = "Martin Bernstorff", email = "martinbernstorff@gmail.com"},
     {name = "Jakob Grøhn Damgaard", email = "bokajgd@gmail.com"},
     {name = "Kenneth Enevoldsen"}]
 
-requires-python = ">=3.8.0,<3.11.0"
+requires-python = ">=3.9.0,<3.11.0"
 
 dependencies = [
     "scipy>=1.8.0,<1.9.4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,8 +60,8 @@ docs = [
 
 text = [
     "transformers>=4.26.0,<4.27.0",
-    "torch>=1.12.1,<1.14.0",
-    "sentence-transformers>=2.2.0,<2.3.0",
+    "torch>=1.0.0,<1.14.0",
+    "sentence-transformers>=2.0.0,<2.5.0",
     "scikit-learn>=1.1.2,<1.4.0",
 ]
 

--- a/src/timeseriesflattener/testing/text_embedding_functions.py
+++ b/src/timeseriesflattener/testing/text_embedding_functions.py
@@ -31,7 +31,7 @@ def bow_test_embedding(text_series: Series) -> DataFrame:
     model = _load_bow_model()
     return pd.DataFrame(
         model.transform(text_series).toarray(),
-        columns=model.get_feature_names(),
+        columns=model.get_feature_names_out(),
     )
 
 

--- a/src/timeseriesflattener/text_embedding_functions.py
+++ b/src/timeseriesflattener/text_embedding_functions.py
@@ -59,5 +59,5 @@ def sklearn_embedding(
     """
     return pd.DataFrame(
         model.transform(text_series).toarray(),
-        columns=model.get_feature_names(),
+        columns=model.get_feature_names_out(),
     )

--- a/tests/test_timeseriesflattener/test_flattened_dataset/test_flattened_dataset.py
+++ b/tests/test_timeseriesflattener/test_flattened_dataset/test_flattened_dataset.py
@@ -2,6 +2,7 @@
 import numpy as np
 import pandas as pd
 import pytest
+
 from timeseriesflattener.feature_spec_objects import (
     OutcomeSpec,
     PredictorSpec,
@@ -63,6 +64,7 @@ def test_add_spec(synth_prediction_times: pd.DataFrame, synth_outcome: pd.DataFr
     # Test adding an invalid spec type
     with pytest.raises(ValueError):
         dataset.add_spec("invalid spec")
+
 
 @pytest.mark.huggingface
 def test_compute_specs(

--- a/tests/test_timeseriesflattener/test_flattened_dataset/test_flattened_dataset.py
+++ b/tests/test_timeseriesflattener/test_flattened_dataset/test_flattened_dataset.py
@@ -2,7 +2,6 @@
 import numpy as np
 import pandas as pd
 import pytest
-
 from timeseriesflattener.feature_spec_objects import (
     OutcomeSpec,
     PredictorSpec,
@@ -14,7 +13,6 @@ from timeseriesflattener.resolve_multiple_functions import latest, mean
 from timeseriesflattener.testing.utils_for_testing import (
     synth_outcome,
     synth_prediction_times,
-    synth_text_data,
 )
 from timeseriesflattener.text_embedding_functions import sentence_transformers_embedding
 
@@ -66,7 +64,7 @@ def test_add_spec(synth_prediction_times: pd.DataFrame, synth_outcome: pd.DataFr
     with pytest.raises(ValueError):
         dataset.add_spec("invalid spec")
 
-
+@pytest.mark.huggingface
 def test_compute_specs(
     synth_prediction_times: pd.DataFrame,
     synth_outcome: pd.DataFrame,


### PR DESCRIPTION
- [ ] I have assigned ranges (e.g. `>=0.1, <0.2`) to all new dependencies (allows dependabot to keep dependency ranges wide for better compatibility)

Fixes #133.
