### PR TITLE
fix: force new release for zenodo upload

### DIFF
--- a/paper/paper.md
+++ b/paper/paper.md
@@ -93,7 +93,7 @@ The package is aimed at researchers and individuals working with irregular time 
 
 
 # Acknowledgements
-This work is supported by the Lundbeck Foundation (grant number: R344-2020-1073), the Danish Cancer Society (grant number: R283-A16461), the Central Denmark Region Fund for Strengthening of Health Science (grant number: 1-36-72-4-20) and the Danish Agency for Digitisation Investment Fund for New Technologies (grant number 2020-6720). 
+This work is supported by the Lundbeck Foundation (grant number: R344-2020-1073), the Danish Cancer Society (grant number: R283-A16461), the Central Denmark Region Fund for Strengthening of Health Science (grant number: 1-36-72-4-20) and the Danish Agency for Digitisation Investment Fund for New Technologies (grant number 2020-6720).
 
 
 # References


### PR DESCRIPTION
Enabled auto-upload of new releases to Zenodo. The only purpose of this PR is to upload the package to Zenodo to finalize the requirements from JOSS