### PR TITLE
fix: erroneous "." in .bib

### DIFF
--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -117,7 +117,7 @@
   doi          = {10.1109/RBME.2020.3007816},
   date         = {2021},
   note         = {Publisher: {IEEE}},
-  doi.         = {10.48550/arXiv.2210.12090}
+  doi          = {10.48550/arXiv.2210.12090}
 }
 
 @article{johnson_mimic-iii_2016,


### PR DESCRIPTION
Removed an added "." in the .bib file for the paper that caused the build of the paper to fail. Incidentally, this PR also marks the start of auto-upload to Zenodo which is required for finalizing the JOSS review.