### PR TITLE
fix optional embedding function and code breaks

### DIFF
--- a/src/timeseriesflattener/feature_spec_objects.py
+++ b/src/timeseriesflattener/feature_spec_objects.py
@@ -604,7 +604,8 @@ class TextPredictorSpec(PredictorSpec):
             """Specification for a text predictor, where the df has been resolved."""
         )
 
-    embedding_fn: Callable = Field(
+    embedding_fn: Optional[Callable] = Field(
+        default=None,
         description="""A function used for embedding the text. Should take a
         pandas series of strings and return a pandas dataframe of embeddings.
         Defaults to: None.""",

--- a/src/timeseriesflattener/flattened_dataset.py
+++ b/src/timeseriesflattener/flattened_dataset.py
@@ -28,6 +28,7 @@ from timeseriesflattener.feature_spec_objects import (
     _AnySpec,
 )
 from timeseriesflattener.flattened_ds_validator import ValidateInitFlattenedDataset
+from timeseriesflattener.resolve_multiple_functions import concatenate
 from timeseriesflattener.utils import print_df_dimensions_diff
 
 log = logging.getLogger(__name__)
@@ -378,7 +379,10 @@ class TimeseriesFlattener:
         )
 
         # handle embedding and dimensionality reduction if text predictor
-        if isinstance(output_spec, TextPredictorSpec):
+        if (
+            isinstance(output_spec, TextPredictorSpec)
+            and output_spec.resolve_multiple_fn == concatenate
+        ):
             df = ColumnHandler.embed_text_column(
                 df=df,
                 text_col_name="value",


### PR DESCRIPTION
# Notes for reviewers
embedding_fn was documented as optional with default None for text specs, but it was not optional with default None. Added that and fixed where the code broke because of that, so we can run the textspecs with other resolve_multiple fns than concatenate. we did talk about whether we should just have used a regular predictorspec for those instead?