### PR TITLE
feat: add feature_name arg to group specs and make non-optional for n…

### DIFF
--- a/docs/tutorials/01_basic.ipynb
+++ b/docs/tutorials/01_basic.ipynb
@@ -1655,6 +1655,7 @@
     "    lookbehind_days=365,\n",
     "    fallback=np.nan,\n",
     "    resolve_multiple_fn=mean,\n",
+    "    feature_name=\"value\",\n",
     ")"
    ]
   },

--- a/docs/tutorials/02_advanced.ipynb
+++ b/docs/tutorials/02_advanced.ipynb
@@ -269,6 +269,7 @@
                 "    lookbehind_days=[365, 730],\n",
                 "    fallback=[np.nan],\n",
                 "    resolve_multiple_fn=[mean, maximum],\n",
+                "    feature_name=\"group_predictors\",\n",
                 ").create_combinations()"
             ]
         },

--- a/src/timeseriesflattener/feature_spec_objects.py
+++ b/src/timeseriesflattener/feature_spec_objects.py
@@ -50,10 +50,8 @@ def resolve_from_dict_or_registry(data: Dict[str, Any]):
     if "values_name" in data and data["values_name"] is not None:
         log.info(f"Resolving values_df from {data['values_name']}")
         data["values_df"] = split_dfs.get(data["values_name"])
-        data["feature_name"] = data["values_name"]
     else:
         if isinstance(data["values_loader"], str):
-            data["feature_name"] = data["values_loader"]
             data["values_loader"] = data_loaders.get(data["values_loader"])
 
         if callable(data["values_loader"]):
@@ -799,6 +797,11 @@ class _MinGroupSpec(BaseModel):
         description="""Optional kwargs for the values_loader.""",
     )
 
+    feature_name: str = Field(
+        description="""The name of the feature. Used for column name generation, e.g.
+            <prefix>_<feature_name>.""",
+    )
+
     def _check_loaders_are_valid(self):
         """Check that all loaders can be resolved from the data_loaders catalogue."""
         invalid_loaders: list = list(
@@ -911,6 +914,9 @@ class PredictorGroupSpec(_MinGroupSpec):
             Prefix for column name, e,g, <prefix>_<feature_name>. Defaults to: pred.
         loader_kwargs (Optional[List[Dict[str, Any]]]):
             Optional kwargs for the values_loader.
+        feature_name (str):
+            The name of the feature. Used for column name generation, e.g.
+            <prefix>_<feature_name>.
         lookbehind_days (List[float]):
             How far behind to look for values
     """
@@ -939,38 +945,41 @@ class OutcomeGroupSpec(_MinGroupSpec):
     """Specification for a group of outcomes.
 
     Fields:
-    values_loader (Optional[Sequence[str]]):
-        Loader for the df. Tries to resolve from the data_loaders
-        registry, then calls the function which should return a dataframe.
-    values_name (Optional[List[str]]):
-        List of strings that corresponds to a key in a dictionary
-        of multiple dataframes that correspods to a name of a type of values.
-    values_df (Optional[DataFrame]):
-        Dataframe with the values.
-    input_col_name_override (Optional[str]):
-        Override for the column name to use as values in df.
-    output_col_name_override (Optional[str]):
-        Override for the column name to use as values in the
-        output df.
-    resolve_multiple_fn (List[Union[Callable, str]]):
-        Name of resolve multiple fn, resolved from
-        resolve_multiple_functions.py
-    fallback (Sequence[Union[Callable, str, float]]):
-        Which value to use if no values are found within interval_days.
-    allowed_nan_value_prop (List[float]):
-        If NaN is higher than this in the input dataframe during
-        resolution, raise an error. Defaults to: [0.0].
-    prefix (str):
-        Prefix for column name, e.g. <prefix>_<feature_name>. Defaults to: outc.
-    loader_kwargs (Optional[List[Dict[str,Any]]]):
-        Optional kwargs for the values_loader.
-    incident (Sequence[bool]):
-        Whether the outcome is incident or not, i.e. whether you
-        can experience it more than once. For example, type 2 diabetes is incident.
-        Incident outcomes can be handled in a vectorised way during resolution,
-         which is faster than non-incident outcomes.
-    lookahead_days (List[float]):
-        How far ahead to look for values
+        values_loader (Optional[Sequence[str]]):
+            Loader for the df. Tries to resolve from the data_loaders
+            registry, then calls the function which should return a dataframe.
+        values_name (Optional[List[str]]):
+            List of strings that corresponds to a key in a dictionary
+            of multiple dataframes that correspods to a name of a type of values.
+        values_df (Optional[DataFrame]):
+            Dataframe with the values.
+        input_col_name_override (Optional[str]):
+            Override for the column name to use as values in df.
+        output_col_name_override (Optional[str]):
+            Override for the column name to use as values in the
+            output df.
+        resolve_multiple_fn (List[Union[Callable, str]]):
+            Name of resolve multiple fn, resolved from
+            resolve_multiple_functions.py
+        fallback (Sequence[Union[Callable, str, float]]):
+            Which value to use if no values are found within interval_days.
+        allowed_nan_value_prop (List[float]):
+            If NaN is higher than this in the input dataframe during
+            resolution, raise an error. Defaults to: [0.0].
+        prefix (str):
+            Prefix for column name, e.g. <prefix>_<feature_name>. Defaults to: outc.
+        loader_kwargs (Optional[List[Dict[str, Any]]]):
+            Optional kwargs for the values_loader.
+        feature_name (str):
+            The name of the feature. Used for column name generation, e.g.
+            <prefix>_<feature_name>.
+        incident (Sequence[bool]):
+            Whether the outcome is incident or not, i.e. whether you
+            can experience it more than once. For example, type 2 diabetes is incident.
+            Incident outcomes can be handled in a vectorised way during resolution,
+             which is faster than non-incident outcomes.
+        lookahead_days (List[float]):
+            How far ahead to look for values
     """
 
     class Doc:
@@ -1028,6 +1037,9 @@ class TextPredictorGroupSpec(PredictorGroupSpec):
             resolution, raise an error. Defaults to: [0.0].
         prefix (str):
             Prefix for column name, e,g, <prefix>_<feature_name>. Defaults to: pred.
+        feature_name (str):
+            The name of the feature. Used for column name generation, e.g.
+            <prefix>_<feature_name>.
         loader_kwargs (Optional[List[Dict[str, Any]]]):
             Optional kwargs for the values_loader.
         lookbehind_days (List[float]):

--- a/tests/test_timeseriesflattener/test_feature_spec_objects.py
+++ b/tests/test_timeseriesflattener/test_feature_spec_objects.py
@@ -37,10 +37,10 @@ def test_anyspec_init():
     spec = _AnySpec(
         values_loader=values_loader_name,
         prefix="test",
+        feature_name="test_feature",
     )
 
     assert isinstance(spec.values_df, pd.DataFrame)
-    assert spec.feature_name == values_loader_name
 
 
 def test_loader_kwargs():
@@ -49,6 +49,7 @@ def test_loader_kwargs():
         values_loader="synth_predictor_float",
         prefix="test",
         loader_kwargs={"n_rows": 10},
+        feature_name="test_feature",
     )
 
     assert len(spec.values_df) == 10
@@ -62,13 +63,18 @@ def test_invalid_multiple_data_args():
             values_loader="synth_predictor_float",
             values_name="synth_data",
             prefix="test",
+            feature_name="test_feature",
         )
 
 
 def test_anyspec_incorrect_values_loader_str():
     """Raise error if values loader is not a key in registry."""
     with pytest.raises(ValueError, match=r".*in registry.*"):
-        _AnySpec(values_loader="I don't exist", prefix="test")
+        _AnySpec(
+            values_loader="I don't exist",
+            prefix="test",
+            feature_name="test_feature",
+        )
 
 
 def test_that_col_names_in_kwargs_exist_in_df():
@@ -101,6 +107,7 @@ def test_create_combinations_while_resolving_from_registry(
         resolve_multiple_fn=["mean"],
         lookbehind_days=[30],
         fallback=[0],
+        feature_name="test_feature",
     ).create_combinations()
 
     assert len(group_spec) == 2
@@ -117,6 +124,7 @@ def test_skip_all_if_no_need_to_process():
                 resolve_multiple_fn=["max"],
                 fallback=[0],
                 allowed_nan_value_prop=[0.5],
+                feature_name="test_feature",
             ).create_combinations(),
         )
         == 1
@@ -132,6 +140,7 @@ def test_skip_one_if_no_need_to_process():
         resolve_multiple_fn=["max", "min"],
         fallback=[0],
         allowed_nan_value_prop=[0],
+        feature_name="test_feature",
     ).create_combinations()
 
     assert len(created_combinations) == 4
@@ -144,6 +153,7 @@ def test_resolve_multiple_fn_to_str():
         lookbehind_days=[365, 730],
         fallback=[np.nan],
         resolve_multiple_fn=[maximum],
+        feature_name="test_feature",
     ).create_combinations()
 
     assert "maximum" in pred_spec_batch[0].get_col_str()
@@ -156,6 +166,7 @@ def test_lookbehind_days_handles_floats():
         lookbehind_days=[2, 0.5],
         fallback=[np.nan],
         resolve_multiple_fn=[maximum],
+        feature_name="test_feature",
     ).create_combinations()
 
     assert pred_spec_batch[1].lookbehind_days == 0.5
@@ -247,6 +258,7 @@ def test_predictorgroupspec_combinations_loader_kwargs():
         resolve_multiple_fn=["bool"],
         fallback=[0],
         lookbehind_days=[10],
+        feature_name="test_feature",
     )
 
     combinations = spec.create_combinations()
@@ -273,6 +285,7 @@ def test_textpredictorgroupspec_combinations_loader_kwargs():
         lookbehind_days=[10],
         embedding_fn=[sklearn_embedding],
         embedding_fn_kwargs=[{"model": bow_model}],
+        feature_name="test_feature",
     )
 
     combinations = spec.create_combinations()

--- a/tests/test_timeseriesflattener/test_flattened_dataset/test_cache.py
+++ b/tests/test_timeseriesflattener/test_flattened_dataset/test_cache.py
@@ -24,6 +24,7 @@ base_float_predictor_combinations = PredictorGroupSpec(
     resolve_multiple_fn=["mean"],
     fallback=[np.NaN],
     allowed_nan_value_prop=[0.0],
+    feature_name="test_feature",
 ).create_combinations()
 
 base_binary_predictor_combinations = PredictorGroupSpec(
@@ -32,6 +33,7 @@ base_binary_predictor_combinations = PredictorGroupSpec(
     resolve_multiple_fn=["max"],
     fallback=[np.NaN],
     allowed_nan_value_prop=[0.0],
+    feature_name="test_feature",
 ).create_combinations()
 
 


### PR DESCRIPTION
…on group specs

## Notes for reviewers
We had some issues with the group specs, because we could not give them names, and that created issues when multiple specs used the same loader (since they all inherited the same name), so I wanted to add it. I got really confused about the resolve_loader function and why in some cases it was set to overwrite the feature_names arg (and also that the feature name was not optional, but to me it seemed the anyspec tests used it as optional?). please let me know a better way to do this 🐟 
