### PR TITLE
feat(#427): add age

### DIFF
--- a/src/timeseriesflattenerv2/_process_spec.py
+++ b/src/timeseriesflattenerv2/_process_spec.py
@@ -15,7 +15,7 @@ from .feature_specs import (
     PredictorSpec,
     ProcessedFrame,
     TimedeltaFrame,
-    TimeFromEventSpec,
+    TimeDeltaSpec,
     TimeMaskedFrame,
     ValueFrame,
     ValueSpecification,
@@ -162,7 +162,7 @@ def process_temporal_spec(
 
 
 def process_time_from_event_spec(
-    spec: TimeFromEventSpec, predictiontime_frame: PredictionTimeFrame
+    spec: TimeDeltaSpec, predictiontime_frame: PredictionTimeFrame
 ) -> ProcessedFrame:
     new_col_name = f"{spec.column_prefix}_{spec.output_name}_fallback_{spec.fallback}"
     prediction_times_with_time_from_event = (
@@ -191,6 +191,6 @@ def process_time_from_event_spec(
 def process_spec(
     spec: ValueSpecification, predictiontime_frame: PredictionTimeFrame
 ) -> ProcessedFrame:
-    if isinstance(spec, TimeFromEventSpec):
+    if isinstance(spec, TimeDeltaSpec):
         return process_time_from_event_spec(spec, predictiontime_frame)
     return process_temporal_spec(spec=spec, predictiontime_frame=predictiontime_frame)

--- a/src/timeseriesflattenerv2/_process_spec.py
+++ b/src/timeseriesflattenerv2/_process_spec.py
@@ -191,7 +191,6 @@ def process_time_from_event_spec(
 def process_spec(
     spec: ValueSpecification, predictiontime_frame: PredictionTimeFrame
 ) -> ProcessedFrame:
-    if isinstance(spec, (PredictorSpec, OutcomeSpec, BooleanOutcomeSpec)):
-        return process_temporal_spec(spec=spec, predictiontime_frame=predictiontime_frame)
-    elif isinstance(spec, TimeFromEventSpec):
+    if isinstance(spec, TimeFromEventSpec):
         return process_time_from_event_spec(spec, predictiontime_frame)
+    return process_temporal_spec(spec=spec, predictiontime_frame=predictiontime_frame)

--- a/src/timeseriesflattenerv2/test_process_spec.py
+++ b/src/timeseriesflattenerv2/test_process_spec.py
@@ -10,7 +10,9 @@ from .feature_specs import (
     LookPeriod,
     PredictionTimeFrame,
     TimedeltaFrame,
+    TimeFromEventSpec,
     TimeMaskedFrame,
+    TimestampValueFrame,
     ValueFrame,
 )
 from .test_flattener import assert_frame_equal
@@ -175,3 +177,35 @@ def test_multiple_aggregators():
     )
 
     assert_frame_equal(aggregated_values.collect(), expected)
+
+
+def test_process_time_from_event_spec():
+    pred_frame = str_to_pl_df(
+        """entity_id,pred_timestamp
+        1,2021-01-01
+        2,2021-01-01
+        """
+    )
+
+    value_frame = str_to_pl_df(
+        """entity_id,timestamp
+        1,2020-01-01"""
+    )
+
+    result = process_spec.process_time_from_event_spec(
+        predictiontime_frame=PredictionTimeFrame(init_df=pred_frame),
+        spec=TimeFromEventSpec(
+            init_frame=TimestampValueFrame(init_df=value_frame),
+            output_name="age_in_years",
+            fallback=0,
+        ),
+    )
+
+    expected = str_to_pl_df(
+        """pred_time_uuid,pred_age_in_years_fallback_0
+1-2021-01-01 00:00:00.000000,1.00274
+2-2021-01-01 00:00:00.000000,0
+       """
+    )
+
+    assert_frame_equal(result.collect(), expected)

--- a/src/timeseriesflattenerv2/test_process_spec.py
+++ b/src/timeseriesflattenerv2/test_process_spec.py
@@ -10,7 +10,7 @@ from .feature_specs import (
     LookPeriod,
     PredictionTimeFrame,
     TimedeltaFrame,
-    TimeFromEventSpec,
+    TimeDeltaSpec,
     TimeMaskedFrame,
     TimestampValueFrame,
     ValueFrame,
@@ -194,7 +194,7 @@ def test_process_time_from_event_spec():
 
     result = process_spec.process_time_from_event_spec(
         predictiontime_frame=PredictionTimeFrame(init_df=pred_frame),
-        spec=TimeFromEventSpec(
+        spec=TimeDeltaSpec(
             init_frame=TimestampValueFrame(init_df=value_frame),
             output_name="age_in_years",
             fallback=0,

--- a/src/timeseriesflattenerv2/test_specs.py
+++ b/src/timeseriesflattenerv2/test_specs.py
@@ -1,10 +1,17 @@
 import datetime as dt
 
 import polars as pl
+import pytest
 
 from timeseriesflattenerv2.aggregators import MeanAggregator
 
-from .feature_specs import OutcomeSpec, PredictorSpec, ValueFrame
+from .feature_specs import (
+    OutcomeSpec,
+    PredictorSpec,
+    TimeDeltaSpec,
+    TimestampValueFrame,
+    ValueFrame,
+)
 
 MockValueFrame = ValueFrame(
     init_df=pl.LazyFrame({"value": [1], "timestamp": ["2021-01-01"], "entity_id": [1]}),
@@ -40,3 +47,17 @@ def test_outcome_spec_post_init():
 
     assert outcome_spec.normalised_lookperiod[0].first == lookdistance_start
     assert outcome_spec.normalised_lookperiod[0].last == lookdistance_end
+
+
+def test_timedelta_spec_error_if_non_unique_ids():
+    with pytest.raises(ValueError, match=".*Expected only one value.*"):
+        TimeDeltaSpec(
+            init_frame=TimestampValueFrame(
+                init_df=pl.LazyFrame(
+                    {"timestamp": ["2021-01-01", "2021-01-02"], "entity_id": [1, 1]}
+                ),
+                value_timestamp_col_name="timestamp",
+            ),
+            fallback=0,
+            output_name="timedelta",
+        )


### PR DESCRIPTION
Very open for comments. Left the naming very open (in case there is a use for getting the time from some event), but might be better to rename to `AgeSpec` or something. Not happy about having to specify the output colname in the spec as we don't do that in other places, but unsure what the best alternative approach is if we want to keep it open for use cases besides age (where it would be easier to hardcode).

feat(#427): add age

Fixes #427

feat: age / time from event spec