### PR TITLE
Feat/490/make_user_facing_specs_and_Flattener_easily_importable_and_put_non-userfacing_into_private_scope

### DIFF
--- a/src/timeseriesflattenerv2/__init__.py
+++ b/src/timeseriesflattenerv2/__init__.py
@@ -1,0 +1,12 @@
+# specs
+from .feature_specs.meta import ValueFrame
+from .feature_specs.from_legacy import PredictorGroupSpec
+from .feature_specs.outcome import OutcomeSpec, BooleanOutcomeSpec
+from .feature_specs.prediction_times import PredictionTimeFrame
+from .feature_specs.predictor import PredictorSpec
+from .feature_specs.static import StaticSpec, StaticFrame
+from .feature_specs.timedelta import TimeDeltaSpec
+from .feature_specs.timestamp_frame import TimestampValueFrame
+
+# flattener
+from .flattener import Flattener


### PR DESCRIPTION
Left aggregators out - seems more intuitive to do `from timeseriesflattener.aggregators import ..`. 

Unsure whether to put the `PredictorGroupSpec` from `from_legacy.py` into top level. Ideally, we don't really want people to use (except perhaps our group for ease of transitioning). Didn't put it for now