### PR TITLE
dev: update requirements-dev.lock and requirements.lock

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ dev = [
 ]
 test = [
   "pytest==7.2.2",
-  "pytest-cov=3.0.0",
+  "pytest-cov==3.0.0",
   "pytest-xdist==3.1.0",
   "pytest-sugar==0.9.7",
   "pytest-testmon==2.1.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,21 +23,21 @@ classifiers = [
 ]
 requires-python = ">=3.8.0,<3.13.0"
 dependencies = [
-    "scipy>=1.8.0",
-    "scikit-learn>=1.1.2",
-    "pydantic>=2.0.0",
-    "pandas>=1.4.0,<=2.1.3",
-    "catalogue>=2.0.0",
-    "numpy>=1.23.3",
-    "pyarrow>=8.0.0",
-    "protobuf<=4.24.4",
-    # Other versions give errors with pytest, super weird!
-    "frozendict>=2.3.4",
-    "coloredlogs>14.0.0",
-    "tqdm>4.1.0",
-    "polars>0.19.0",
-    "iterpy>=1.6.0",
-    "rich>=13.0.0",
+  "scipy>=1.8.0",
+  "scikit-learn>=1.1.2",
+  "pydantic>=2.0.0",
+  "pandas>=1.4.0,<=2.1.3",
+  "catalogue>=2.0.0",
+  "numpy>=1.23.3",
+  "pyarrow>=8.0.0",
+  "protobuf<=4.24.4",
+  # Other versions give errors with pytest, super weird!
+  "frozendict>=2.3.4",
+  "coloredlogs>14.0.0",
+  "tqdm>4.1.0",
+  "polars>0.19.0",
+  "iterpy>=1.6.0",
+  "rich>=13.0.0",
 ]
 
 [project.license]
@@ -47,16 +47,15 @@ file = "LICENSE"
 dev = [
   "pyright==1.1.330.post0",
   "pre-commit==3.4.0",
-  "ruff==0.2.1",            # important that these match the pre-commit hooks
-  "pandas-stubs",           # type stubs for pandas
+  "ruff==0.2.1",                # important that these match the pre-commit hooks
+  "pandas-stubs==2.2.0.240218", # type stubs for pandas
   "invoke==2.1.1",
-  "lumberman",
 ]
 test = [
-  "pytest>=7.1.3,<7.3.0",
-  "pytest-cov>=3.0.0,<3.1.0",
-  "pytest-xdist>=3.0.0,<3.2.0",
-  "pytest-sugar>=0.9.4,<0.10.0",
+  "pytest==7.2.2",
+  "pytest-cov=3.0.0",
+  "pytest-xdist==3.1.0",
+  "pytest-sugar==0.9.7",
   "pytest-testmon==2.1.0",
   "pytest-benchmark==4.0.0",
   "pytest-codspeed==2.2.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
   "coloredlogs>14.0.0",
   "tqdm>4.1.0",
   "polars>0.19.0",
-  "iterpy>=1.6.0",
+  "iterpy==1.6.0",
   "rich>=13.0.0",
 ]
 

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -10,89 +10,38 @@
 -e file:.
 annotated-types==0.6.0
     # via pydantic
-appnope==0.1.4
-    # via ipykernel
-asttokens==2.4.1
-    # via stack-data
 attrs==23.2.0
-    # via jsonschema
     # via pytest
-    # via referencing
-    # via sphobjinv
 catalogue==2.0.10
     # via timeseriesflattener
-certifi==2024.2.2
-    # via sphobjinv
 cffi==1.15.1
     # via pytest-codspeed
-click==8.1.7
-    # via quartodoc
-    # via skimpy
-colorama==0.4.6
-    # via griffe
 coloredlogs==15.0.1
     # via timeseriesflattener
-comm==0.2.1
-    # via ipykernel
 coverage==7.4.2
     # via pytest-cov
     # via pytest-testmon
-debugpy==1.8.1
-    # via ipykernel
-decorator==5.1.1
-    # via ipython
 exceptiongroup==1.2.0
-    # via ipython
     # via pytest
 execnet==2.0.2
     # via pytest-xdist
-executing==2.0.1
-    # via stack-data
 filelock==3.12.4
     # via pytest-codspeed
 frozendict==2.4.0
     # via timeseriesflattener
-griffe==0.40.1
-    # via quartodoc
 humanfriendly==10.0
     # via coloredlogs
-importlib-metadata==7.0.1
-    # via jupyter-client
-    # via quartodoc
-    # via typeguard
-importlib-resources==6.1.1
-    # via quartodoc
 iniconfig==2.0.0
     # via pytest
 invoke==2.1.1
-ipykernel==6.29.2
-    # via skimpy
-ipython==8.18.1
-    # via ipykernel
 iterpy==1.6.0
     # via timeseriesflattener
-jedi==0.19.1
-    # via ipython
 joblib==1.3.2
     # via scikit-learn
-jsonschema==4.21.1
-    # via sphobjinv
-jsonschema-specifications==2023.12.1
-    # via jsonschema
-jupyter-client==8.6.0
-    # via ipykernel
-jupyter-core==5.7.1
-    # via ipykernel
-    # via jupyter-client
 markdown-it-py==3.0.0
     # via rich
-matplotlib-inline==0.1.6
-    # via ipykernel
-    # via ipython
 mdurl==0.1.2
     # via markdown-it-py
-nest-asyncio==1.6.0
-    # via ipykernel
 nodeenv==1.8.0
     # via pyright
 numpy==1.26.4
@@ -101,55 +50,31 @@ numpy==1.26.4
     # via pyarrow
     # via scikit-learn
     # via scipy
-    # via skimpy
     # via timeseriesflattener
 packaging==23.2
-    # via ipykernel
     # via pytest
     # via pytest-sugar
 pandas==2.1.3
-    # via skimpy
     # via timeseriesflattener
 pandas-stubs==2.2.0.240218
-parso==0.8.3
-    # via jedi
-pexpect==4.9.0
-    # via ipython
-platformdirs==4.2.0
-    # via jupyter-core
 pluggy==1.4.0
     # via pytest
-plum-dispatch==1.7.4
-    # via quartodoc
 polars==0.20.10
-    # via skimpy
     # via timeseriesflattener
-prompt-toolkit==3.0.43
-    # via ipython
 protobuf==4.24.4
     # via timeseriesflattener
-psutil==5.9.8
-    # via ipykernel
-ptyprocess==0.7.0
-    # via pexpect
-pure-eval==0.2.2
-    # via stack-data
 py-cpuinfo==9.0.0
     # via pytest-benchmark
 pyarrow==15.0.0
-    # via skimpy
     # via timeseriesflattener
 pycparser==2.21
     # via cffi
 pydantic==2.6.1
-    # via quartodoc
     # via timeseriesflattener
 pydantic-core==2.16.2
     # via pydantic
 pygments==2.17.2
-    # via ipython
     # via rich
-    # via skimpy
 pyright==1.1.330.post0
 pytest==7.2.2
     # via pytest-benchmark
@@ -165,26 +90,11 @@ pytest-sugar==0.9.7
 pytest-testmon==2.1.0
 pytest-xdist==3.1.0
 python-dateutil==2.8.2
-    # via jupyter-client
     # via pandas
 pytz==2024.1
     # via pandas
-pyyaml==6.0.1
-    # via quartodoc
-pyzmq==25.1.2
-    # via ipykernel
-    # via jupyter-client
-quartodoc==0.7.2
-    # via skimpy
-referencing==0.33.0
-    # via jsonschema
-    # via jsonschema-specifications
 rich==13.7.0
-    # via skimpy
     # via timeseriesflattener
-rpds-py==0.18.0
-    # via jsonschema
-    # via referencing
 ruff==0.2.2
 scikit-learn==1.4.1.post1
     # via timeseriesflattener
@@ -194,16 +104,7 @@ scipy==1.12.0
 setuptools==69.1.0
     # via nodeenv
 six==1.16.0
-    # via asttokens
     # via python-dateutil
-skimpy==0.0.14
-    # via timeseriesflattener
-sphobjinv==2.3.1
-    # via quartodoc
-stack-data==0.6.3
-    # via ipython
-tabulate==0.9.0
-    # via quartodoc
 termcolor==2.4.0
     # via pytest-sugar
 threadpoolctl==3.3.0
@@ -211,34 +112,12 @@ threadpoolctl==3.3.0
 tomli==2.0.1
     # via coverage
     # via pytest
-tornado==6.4
-    # via ipykernel
-    # via jupyter-client
 tqdm==4.66.2
     # via timeseriesflattener
-traitlets==5.14.1
-    # via comm
-    # via ipykernel
-    # via ipython
-    # via jupyter-client
-    # via jupyter-core
-    # via matplotlib-inline
-typeguard==4.1.5
-    # via skimpy
 types-pytz==2024.1.0.20240203
     # via pandas-stubs
 typing-extensions==4.9.0
-    # via ipython
     # via pydantic
     # via pydantic-core
-    # via quartodoc
-    # via typeguard
 tzdata==2024.1
     # via pandas
-watchdog==4.0.0
-    # via quartodoc
-wcwidth==0.2.13
-    # via prompt-toolkit
-zipp==3.17.0
-    # via importlib-metadata
-    # via importlib-resources

--- a/requirements.lock
+++ b/requirements.lock
@@ -10,185 +10,61 @@
 -e file:.
 annotated-types==0.6.0
     # via pydantic
-appnope==0.1.4
-    # via ipykernel
-asttokens==2.4.1
-    # via stack-data
-attrs==23.2.0
-    # via jsonschema
-    # via referencing
-    # via sphobjinv
 catalogue==2.0.10
     # via timeseriesflattener
-certifi==2024.2.2
-    # via sphobjinv
-click==8.1.7
-    # via quartodoc
-    # via skimpy
-colorama==0.4.6
-    # via griffe
 coloredlogs==15.0.1
     # via timeseriesflattener
-comm==0.2.1
-    # via ipykernel
-debugpy==1.8.1
-    # via ipykernel
-decorator==5.1.1
-    # via ipython
-exceptiongroup==1.2.0
-    # via ipython
-executing==2.0.1
-    # via stack-data
 frozendict==2.4.0
     # via timeseriesflattener
-griffe==0.40.1
-    # via quartodoc
 humanfriendly==10.0
     # via coloredlogs
-importlib-metadata==7.0.1
-    # via jupyter-client
-    # via quartodoc
-    # via typeguard
-importlib-resources==6.1.1
-    # via quartodoc
-ipykernel==6.29.2
-    # via skimpy
-ipython==8.18.1
-    # via ipykernel
 iterpy==1.6.0
     # via timeseriesflattener
-jedi==0.19.1
-    # via ipython
 joblib==1.3.2
     # via scikit-learn
-jsonschema==4.21.1
-    # via sphobjinv
-jsonschema-specifications==2023.12.1
-    # via jsonschema
-jupyter-client==8.6.0
-    # via ipykernel
-jupyter-core==5.7.1
-    # via ipykernel
-    # via jupyter-client
 markdown-it-py==3.0.0
     # via rich
-matplotlib-inline==0.1.6
-    # via ipykernel
-    # via ipython
 mdurl==0.1.2
     # via markdown-it-py
-nest-asyncio==1.6.0
-    # via ipykernel
 numpy==1.26.4
     # via pandas
     # via pyarrow
     # via scikit-learn
     # via scipy
-    # via skimpy
     # via timeseriesflattener
-packaging==23.2
-    # via ipykernel
 pandas==2.1.3
-    # via skimpy
     # via timeseriesflattener
-parso==0.8.3
-    # via jedi
-pexpect==4.9.0
-    # via ipython
-platformdirs==4.2.0
-    # via jupyter-core
-plum-dispatch==1.7.4
-    # via quartodoc
 polars==0.20.10
-    # via skimpy
     # via timeseriesflattener
-prompt-toolkit==3.0.43
-    # via ipython
 protobuf==4.24.4
     # via timeseriesflattener
-psutil==5.9.8
-    # via ipykernel
-ptyprocess==0.7.0
-    # via pexpect
-pure-eval==0.2.2
-    # via stack-data
 pyarrow==15.0.0
-    # via skimpy
     # via timeseriesflattener
 pydantic==2.6.1
-    # via quartodoc
     # via timeseriesflattener
 pydantic-core==2.16.2
     # via pydantic
 pygments==2.17.2
-    # via ipython
     # via rich
-    # via skimpy
 python-dateutil==2.8.2
-    # via jupyter-client
     # via pandas
 pytz==2024.1
     # via pandas
-pyyaml==6.0.1
-    # via quartodoc
-pyzmq==25.1.2
-    # via ipykernel
-    # via jupyter-client
-quartodoc==0.7.2
-    # via skimpy
-referencing==0.33.0
-    # via jsonschema
-    # via jsonschema-specifications
 rich==13.7.0
-    # via skimpy
     # via timeseriesflattener
-rpds-py==0.18.0
-    # via jsonschema
-    # via referencing
 scikit-learn==1.4.1.post1
     # via timeseriesflattener
 scipy==1.12.0
     # via scikit-learn
     # via timeseriesflattener
 six==1.16.0
-    # via asttokens
     # via python-dateutil
-skimpy==0.0.14
-    # via timeseriesflattener
-sphobjinv==2.3.1
-    # via quartodoc
-stack-data==0.6.3
-    # via ipython
-tabulate==0.9.0
-    # via quartodoc
 threadpoolctl==3.3.0
     # via scikit-learn
-tornado==6.4
-    # via ipykernel
-    # via jupyter-client
 tqdm==4.66.2
     # via timeseriesflattener
-traitlets==5.14.1
-    # via comm
-    # via ipykernel
-    # via ipython
-    # via jupyter-client
-    # via jupyter-core
-    # via matplotlib-inline
-typeguard==4.1.5
-    # via skimpy
 typing-extensions==4.9.0
-    # via ipython
     # via pydantic
     # via pydantic-core
-    # via quartodoc
-    # via typeguard
 tzdata==2024.1
     # via pandas
-watchdog==4.0.0
-    # via quartodoc
-wcwidth==0.2.13
-    # via prompt-toolkit
-zipp==3.17.0
-    # via importlib-metadata
-    # via importlib-resources

--- a/src/timeseriesflattener/spec_processors/temporal.py
+++ b/src/timeseriesflattener/spec_processors/temporal.py
@@ -174,7 +174,7 @@ def process_temporal_spec(
 
     return ProcessedFrame(
         df=horizontally_concatenate_dfs(
-            aggregated_value_frames.to_list(),
+            dfs=aggregated_value_frames.to_list(),
             pred_time_uuid_col_name=predictiontime_frame.pred_time_uuid_col_name,
         ),
         pred_time_uuid_col_name=predictiontime_frame.pred_time_uuid_col_name,


### PR DESCRIPTION
Turns out the error was because of a change I made to `iterpy`. For those interested, when I called `flatten`, it flattens if the object is iterable. A dataframe is iterable, and if flattened, it returns a sequence of series. That meant we called dataframe methods on sequences of series, which obviously does not work.

Sorry about that @sarakolding! Good thing you asked, and only fair I fix it.

To get your PR up to date, rebuild the environment.

I have pinned the `iterpy` version in this project so it never changes and we do not get similar errors in the future.