### PR TITLE
bug(#559): using step_size with multiple features leads to misaligned join

### DIFF
--- a/src/timeseriesflattener/flattener.py
+++ b/src/timeseriesflattener/flattener.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
+import datetime as dt
 from dataclasses import dataclass
 from functools import partial
 from multiprocessing import Pool
 from typing import TYPE_CHECKING, Union
-import datetime as dt
 
 import polars as pl
 import tqdm
@@ -127,6 +127,10 @@ class Flattener:
             self.predictiontime_frame.df = self.predictiontime_frame.df.lazy()
             for spec in specs:
                 spec.value_frame.df = spec.value_frame.df.lazy()
+
+        self.predictiontime_frame.df = self.predictiontime_frame.df.sort(
+            self.predictiontime_frame.timestamp_col_name
+        )  # type: ignore
 
         # Process and collect the specs. One-by-one, to get feedback on progress.
         dfs: Sequence[pl.LazyFrame] = []


### PR DESCRIPTION
Predictions times are now sorted before being processed ensuring that features are generated in the same order for specs using step_size and those not.

bug(#559): using step_size with multiple features leads to misaligned join

Fixes #559

fix: scrambled features with step size