### PR TITLE
feat: add new UniqueCountAggregator

### DIFF
--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -84,7 +84,7 @@ pytest==7.2.2
     # via pytest-testmon
     # via pytest-xdist
 pytest-benchmark==4.0.0
-pytest-codspeed==2.2.0
+pytest-codspeed==3.0.1
 pytest-cov==3.0.0
 pytest-sugar==0.9.7
 pytest-testmon==2.1.0

--- a/src/timeseriesflattener/aggregators_test.py
+++ b/src/timeseriesflattener/aggregators_test.py
@@ -11,6 +11,7 @@ from timeseriesflattener.testing.utils_for_testing import str_to_pl_df
 from .intermediary import TimeMaskedFrame
 from .aggregators import (
     CountAggregator,
+    UniqueCountAggregator,
     EarliestAggregator,
     HasValuesAggregator,
     LatestAggregator,
@@ -84,6 +85,9 @@ AggregatorExampleType = Union[ComplexAggregatorExample, SingleVarAggregatorExamp
         ),
         SingleVarAggregatorExample(
             aggregator=CountAggregator(), input_values=[1, 2], expected_output_values=[2]
+        ),
+        SingleVarAggregatorExample(
+            aggregator=CountAggregator(), input_values=[1, 2, 1], expected_output_values=[2]
         ),
         SingleVarAggregatorExample(
             aggregator=SumAggregator(), input_values=[1, 2], expected_output_values=[3]

--- a/src/timeseriesflattener/aggregators_test.py
+++ b/src/timeseriesflattener/aggregators_test.py
@@ -87,7 +87,7 @@ AggregatorExampleType = Union[ComplexAggregatorExample, SingleVarAggregatorExamp
             aggregator=CountAggregator(), input_values=[1, 2], expected_output_values=[2]
         ),
         SingleVarAggregatorExample(
-            aggregator=CountAggregator(), input_values=[1, 2, 1], expected_output_values=[2]
+            aggregator=UniqueCountAggregator(), input_values=[1, 2, 1], expected_output_values=[2]
         ),
         SingleVarAggregatorExample(
             aggregator=SumAggregator(), input_values=[1, 2], expected_output_values=[3]


### PR DESCRIPTION
Adds an aggregator that can count number of unique instances, e.g. unique medication codes. 

Input:
`
prediction_time_uuid,timestamp,value
1,2013-01-01,1,
1,2013-01-02,2,
1,2013-01-04,3,
1,2013-01-03,1
`

Expected output:
`3`



Fixes #629

